### PR TITLE
GitHub Pages: set Vite base to /shagworm-goldbug-2025/

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
-  base: "/goldbug-2025/",
+  base: "/shagworm-goldbug-2025/",
   plugins: [react()],
   resolve: {
     alias: {
@@ -11,4 +11,3 @@ export default defineConfig({
     },
   },
 })
-


### PR DESCRIPTION
This PR sets Vite base to /shagworm-goldbug-2025/ so assets resolve correctly on GitHub Pages. It uses the existing Pages workflow to build and deploy. Assisted by Devin.